### PR TITLE
Rs identifiers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@
 
 # Other auto-generated files
 **/__pycache__
+
+# rqt log file
+*/rqt_log.txt

--- a/launch/ogc_airtest.launch
+++ b/launch/ogc_airtest.launch
@@ -16,7 +16,7 @@
 	<arg name="router_username" default="root" />
 	<arg name="router_ip" default="192.168.1.1" />
 	<arg name="link_select" default="0" />
-	<arg name="waypoint_folder" default="$(env HOME)/Waypoints/"/>
+	<arg name="waypoint_folder" default="$(env HOME)/Sync/Waypoints/"/>
 	
 	<!-- identifiers args -->
 	<arg name="identifiers_file" default="$(env HOME)/Sync/identifiers.json" />

--- a/launch/ogc_airtest.launch
+++ b/launch/ogc_airtest.launch
@@ -20,10 +20,12 @@
 	
 	<!-- identifiers args -->
 	<arg name="identifiers_file" default="$(env HOME)/identifiers.json" />
-	<arg name="ground_ids" default="[1]" />
-	<arg name="self_id" default="1" />
+	<!-- <arg name="ground_ids" default="[1]" /> -->
+	<!-- <arg name="self_id" default="1" /> -->
 	<arg name="is_air" default="True" />
-
+	<arg name="valid_ids_file" default="$(env HOME)/.valid_ids" />
+	<arg name="self_id_file" default="$(env HOME)/.self_id" />
+	
 	<!-- tele args -->
 	<arg name="tdlib_auth_dir" default="$(env HOME)/.tdlib"/>
 
@@ -49,7 +51,6 @@
 	<node pkg="telegram" type="telegram_link" name="telegram_link" 
 	respawn="true" respawn_delay="3" output="$(arg log_output)" >
 		<param name="tdlib_auth_dir" value="$(arg tdlib_auth_dir)" />
-		<rosparam param="valid_ids" subst_value="True">$(arg ground_ids)</rosparam>
 	</node>
 
 	<!-- sms_link node -->
@@ -70,8 +71,8 @@
 	<node pkg="identifiers" type="identifiers_server" name="identifiers_server" respawn="true" respawn_delay="3" output="$(arg log_output)" >
 		<param name="identifiers_file" value="$(arg identifiers_file)" />
 		<param name="is_air" value="$(arg is_air)" />
-		<param name="self_id" value="$(arg self_id)" />
-		<rosparam param="valid_ids" subst_value="True">$(arg ground_ids)</rosparam>
+		<param name="self_id_file" value="$(arg self_id_file)" />
+		<param name="valid_ids_file" value="$(arg valid_ids_file)" />
 	</node>
 
 	<!-- air despatcher node -->
@@ -80,7 +81,6 @@
         <rosparam param="ground_ids" subst_value="True">$(arg ground_ids)</rosparam>x
 		<param name="interval_1" value="$(arg interval_1)" />
 		<param name="interval_2" value="$(arg interval_2)" />
-		<param name="self_id" value="$(arg self_id)" />
 		<param name="link_select" value="$(arg link_select)" />
 		<param name="waypoint_folder" value="$(arg waypoint_folder)"/>
 	</node>

--- a/launch/ogc_airtest.launch
+++ b/launch/ogc_airtest.launch
@@ -19,9 +19,7 @@
 	<arg name="waypoint_folder" default="$(env HOME)/Waypoints/"/>
 	
 	<!-- identifiers args -->
-	<arg name="identifiers_file" default="$(env HOME)/identifiers.json" />
-	<!-- <arg name="ground_ids" default="[1]" /> -->
-	<!-- <arg name="self_id" default="1" /> -->
+	<arg name="identifiers_file" default="$(env HOME)/Sync/identifiers.json" />
 	<arg name="is_air" default="True" />
 	<arg name="valid_ids_file" default="$(env HOME)/.valid_ids" />
 	<arg name="self_id_file" default="$(env HOME)/.self_id" />
@@ -78,7 +76,6 @@
 	<!-- air despatcher node -->
 	<node pkg="despatcher" type="air_despatcher.py" name="air_despatcher" 
 	respawn="true" respawn_delay="3" output="$(arg log_output)">
-        <rosparam param="ground_ids" subst_value="True">$(arg ground_ids)</rosparam>x
 		<param name="interval_1" value="$(arg interval_1)" />
 		<param name="interval_2" value="$(arg interval_2)" />
 		<param name="link_select" value="$(arg link_select)" />

--- a/launch/ogc_gndtest.launch
+++ b/launch/ogc_gndtest.launch
@@ -60,7 +60,6 @@
 	<!-- gnd despatcher node -->
 	<node pkg="despatcher" type="gnd_despatcher.py" name="gnd_despatcher" 
 	respawn="true" respawn_delay="3" output="$(arg log_output)">
-		<param name="link_select" value="$(arg link_select)" />
 		<param name="interval_1" value="$(arg interval_1)" />
 		<param name="interval_2" value="$(arg interval_2)" />
 		<param name="interval_3" value="$(arg interval_3)" />

--- a/launch/ogc_gndtest.launch
+++ b/launch/ogc_gndtest.launch
@@ -11,15 +11,12 @@
 
 	<!-- identifiers args -->
 	<arg name="identifiers_file" default="$(env HOME)/Sync/identifiers.json" />
-	<!-- <arg name="air_ids" default="[1]" /> -->
-	<arg name="self_id" default="1" />
 	<arg name="is_air" default="False" />
 	<arg name="valid_ids_file" default="$(env HOME)/.valid_ids" />
 	<arg name="self_id_file" default="$(env HOME)/.self_id" />
-
 	
 	<!-- tele args -->
-	<arg name="tdlib_auth_dir" default="$(env HOME)/.tdlib"/>
+	<arg name="tdlib_auth_dir" default="$(env HOME)/.tdlib_gnd"/>
 
 	<!-- sbd args -->
 	<arg name="portID" default="/dev/ttyUSB0"/>
@@ -41,8 +38,7 @@
 	<node pkg="sbd" type="sbd_gnd_link.py" name="sbd_gnd_link"
 	respawn="true" respawn_delay="3" output="$(arg log_output)">
 		<param name="interval" value="$(arg interval_3)" />
-        <param name="portID" value="$(arg portID)" />
-		<param name="self_id" value="$(arg self_id)" />
+		<param name="portID" value="$(arg portID)" />
 	</node>
 
 	<node pkg="identifiers" type="identifiers_server" name="identifiers_server" respawn="true" respawn_delay="3" output="$(arg log_output)" >

--- a/launch/ogc_gndtest.launch
+++ b/launch/ogc_gndtest.launch
@@ -15,7 +15,7 @@
 	<arg name="self_id_file" default="$(env HOME)/.self_id" />
 	
 	<!-- tele args -->
-	<arg name="tdlib_auth_dir" default="$(env HOME)/.tdlib_gnd"/>
+	<arg name="tdlib_auth_dir" default="$(env HOME)/.tdlib"/>
 
 	<!-- sbd args -->
 	<arg name="portID" default="/dev/ttyUSB0"/>

--- a/launch/ogc_gndtest.launch
+++ b/launch/ogc_gndtest.launch
@@ -10,10 +10,13 @@
 	<arg name="link_select" default="0" />
 
 	<!-- identifiers args -->
-	<arg name="identifiers_file" default="$(env HOME)/identifiers.json" />
-	<arg name="air_ids" default="[1]" />
+	<arg name="identifiers_file" default="$(env HOME)/Sync/identifiers.json" />
+	<!-- <arg name="air_ids" default="[1]" /> -->
 	<arg name="self_id" default="1" />
 	<arg name="is_air" default="False" />
+	<arg name="valid_ids_file" default="$(env HOME)/.valid_ids" />
+	<arg name="self_id_file" default="$(env HOME)/.self_id" />
+
 	
 	<!-- tele args -->
 	<arg name="tdlib_auth_dir" default="$(env HOME)/.tdlib"/>
@@ -25,7 +28,6 @@
 	<node pkg="telegram" type="telegram_link" name="telegram_link" 
 	respawn="true" respawn_delay="3" output="$(arg log_output)" >
 		<param name="tdlib_auth_dir" value="$(arg tdlib_auth_dir)" />
-		<rosparam param="valid_ids" subst_value="True">$(arg air_ids)</rosparam>
 	</node>
 
 	<!-- sms_link node -->
@@ -46,14 +48,13 @@
 	<node pkg="identifiers" type="identifiers_server" name="identifiers_server" respawn="true" respawn_delay="3" output="$(arg log_output)" >
 		<param name="identifiers_file" value="$(arg identifiers_file)" />
 		<param name="is_air" value="$(arg is_air)" />
-		<param name="self_id" value="$(arg self_id)" />
-		<rosparam param="valid_ids" subst_value="True">$(arg air_ids)</rosparam>
+		<param name="self_id_file" value="$(arg self_id_file)" />
+		<param name="valid_ids_file" value="$(arg valid_ids_file)" />
 	</node>
 
 	<!-- gnd despatcher node -->
 	<node pkg="despatcher" type="gnd_despatcher.py" name="gnd_despatcher" 
 	respawn="true" respawn_delay="3" output="$(arg log_output)">
-		<param name="self_id" value="$(arg self_id)" />
 		<param name="link_select" value="$(arg link_select)" />
 	</node>
 

--- a/ogc_ws/src/despatcher/src/air_despatcher.py
+++ b/ogc_ws/src/despatcher/src/air_despatcher.py
@@ -78,7 +78,7 @@ class airdespatcher():
 
         # Air Identifiers (attached to outgoing msgs)
         self._is_air = 1 # 1 = Aircraft, 0 = GCS. Obviously, air despatcher should be on an aircraft...
-        self._id = ids_get_self_id()
+        self._id = ids_get_self_id().data_int
         # self._id = rospy.get_param("~self_id") # Our aircraft ID
 
         # Ground Identifiers. For now we assume only one GCS

--- a/ogc_ws/src/despatcher/src/air_despatcher.py
+++ b/ogc_ws/src/despatcher/src/air_despatcher.py
@@ -71,7 +71,6 @@ class airdespatcher():
         self._regular_payload_flag = True # Whether we should send regular payload to Ground Control
         self._statustext_flag = True # Whether we should send status texts to Ground Control
         self.payloads = air_payload() # Handler for regular and on-demand payloads
-        self.link_select = rospy.get_param("~link_select") # 0 = Tele, 1 = SMS, 2 = SBD
         self._prev_transmit_time = rospy.get_rostime().secs # Transmit time of previous incoming msg
 
 

--- a/ogc_ws/src/despatcher/src/air_despatcher.py
+++ b/ogc_ws/src/despatcher/src/air_despatcher.py
@@ -39,6 +39,8 @@ from std_msgs.msg import String
 from statustext.msg import YonahStatusText
 from despatcher.msg import LinkMessage
 
+from identifiers.srv import GetSelfDetails, GetIds
+
 # Local
 from regular import air_payload
 import waypoint
@@ -68,12 +70,20 @@ class airdespatcher():
         self.link_select = rospy.get_param("~link_select") # 0 = Tele, 1 = SMS, 2 = SBD
         self._prev_transmit_time = rospy.get_rostime().secs # Transmit time of previous incoming msg
 
+
+        rospy.wait_for_service("identifiers/self/self_id")
+        rospy.wait_for_service("identifiers/get/valid_ids")
+        ids_get_self_id = rospy.ServiceProxy("identifiers/self/self_id", GetSelfDetails)
+        ids_get_valid_ids = rospy.ServiceProxy("identifiers/get/valid_ids", GetIds)
+
         # Air Identifiers (attached to outgoing msgs)
         self._is_air = 1 # 1 = Aircraft, 0 = GCS. Obviously, air despatcher should be on an aircraft...
-        self._id = rospy.get_param("~self_id") # Our aircraft ID
+        self._id = ids_get_self_id()
+        # self._id = rospy.get_param("~self_id") # Our aircraft ID
 
         # Ground Identifiers. For now we assume only one GCS
-        self.ground_id = rospy.get_param("~ground_ids")[0]
+        # self.ground_id = rospy.get_param("~ground_ids")[0]
+        self.ground_id = ids_get_valid_ids().ids[0]
 
         # Intervals btwn msgs
         self._interval_1 = rospy.get_param("~interval_1") # Short time interval (seconds) for regular payload

--- a/ogc_ws/src/despatcher/src/gnd_despatcher.py
+++ b/ogc_ws/src/despatcher/src/gnd_despatcher.py
@@ -27,6 +27,7 @@ import rospkg
 from std_msgs.msg import String
 from despatcher.msg import RegularPayload
 from despatcher.msg import LinkMessage
+from identifiers.srv import GetSelfDetails
 
 # Local
 import regular
@@ -48,9 +49,13 @@ class gnddespatcher():
         # Link switching
         self.link_select = rospy.get_param("~link_select") # 0 = Tele, 1 = SMS, 2 = SBD
 
+        rospy.wait_for_service("identifiers/self/self_id")
+        ids_get_self_id = rospy.ServiceProxy("identifiers/self/self_id", GetSelfDetails)
+
         # Gnd Identifiers and msg headers (attached to outgoing msgs)
         self._is_air = 0 # 1 = Aircraft, 0 = GCS. Obviously, gnd despatcher should be on a GCS...
-        self._id = rospy.get_param("~self_id") # Our GCS ID
+        # self._id = rospy.get_param("~self_id") # Our GCS ID
+        self._id = ids_get_self_id()
         self._severity = "i" # Outgoing msg severity level
 
         # Used to handle incoming msgs

--- a/ogc_ws/src/despatcher/src/gnd_despatcher.py
+++ b/ogc_ws/src/despatcher/src/gnd_despatcher.py
@@ -55,7 +55,7 @@ class gnddespatcher():
         # Gnd Identifiers and msg headers (attached to outgoing msgs)
         self._is_air = 0 # 1 = Aircraft, 0 = GCS. Obviously, gnd despatcher should be on a GCS...
         # self._id = rospy.get_param("~self_id") # Our GCS ID
-        self._id = ids_get_self_id()
+        self._id = ids_get_self_id().data_int
         self._severity = "i" # Outgoing msg severity level
 
         # Used to handle incoming msgs

--- a/ogc_ws/src/despatcher/src/gnd_despatcher.py
+++ b/ogc_ws/src/despatcher/src/gnd_despatcher.py
@@ -102,9 +102,6 @@ class gnddespatcher():
         self.pub_to_statustext = rospy.Publisher('ogc/from_despatcher/statustext', String, queue_size=5)
         self.file_to_telegram = rospy.Publisher('ogc/to_telegram/file', LinkMessage, queue_size = 5) # Link to Telegram node
 
-        # Link switching
-        self.link_select = rospy.get_param("~link_select") # 0 = Tele, 1 = SMS, 2 = SBD
-
         rospy.wait_for_service("identifiers/self/self_id")
         ids_get_self_id = rospy.ServiceProxy("identifiers/self/self_id", GetSelfDetails)
 

--- a/ogc_ws/src/identifiers/scripts/identifiers.py
+++ b/ogc_ws/src/identifiers/scripts/identifiers.py
@@ -50,13 +50,14 @@ class Identifiers:
 		else:
 			self.admin = True
 
-		try:
-			with open(self_id_file, "r") as f:
-				self.self_id = int(f.readline().rstrip())
-		except FileNotFoundError:
-			print("seld_id file is not available")
-			print("Please ensure the device was properly set up")
-			exit()
+		if not admin:
+			try:
+				with open(self_id_file, "r") as f:
+					self.self_id = int(f.readline().rstrip())
+			except FileNotFoundError:
+				print("self_id file is not available")
+				print("Please ensure the device was properly set up")
+				exit()
 
 		self.whitelist = []					# List of whitelisted devices (contains instances of the Device class)
 		self.whitelist_nums = []			# List of whitelisted numbers (contains phone number of the whitelisted devices)

--- a/ogc_ws/src/identifiers/scripts/identifiers.py
+++ b/ogc_ws/src/identifiers/scripts/identifiers.py
@@ -29,10 +29,10 @@ class Device:
 		self.telegram_id = telegram_id
 
 class Identifiers:
-	def __init__(self, json_file, is_air, self_id, valid_ids_file):
+	def __init__(self, json_file, is_air, self_id_file, valid_ids_file):
 		self.json_file = json_file			# Location of identifiers file
 		self.is_air = is_air				# Boolean to know if it is running air side or ground side
-		self.self_id = self_id 				# id number as defined in the identifiers file of the device this runs on
+		# self.self_id = self_id 				# id number as defined in the identifiers file of the device this runs on
 		self.self_device = None				# Information about the device this runs one
 		self.valid_ids = []					# List of whitelisted ids as defined the identifiers file
 
@@ -46,6 +46,15 @@ class Identifiers:
 				print("Valid ids file is not available")
 				print("please check that the telegram_bone script works properly")
 				exit()
+
+		try:
+			with open(self_id_file, "r") as f:
+				self.self_id = int(f.readline().rstrip())
+				print(self.self_id)
+		except FileNotFoundError:
+			print("seld_id file is not available")
+			print("Please ensure the device was properly set up")
+			exit()
 
 		self.whitelist = []					# List of whitelisted devices (contains instances of the Device class)
 		self.whitelist_nums = []			# List of whitelisted numbers (contains phone number of the whitelisted devices)
@@ -196,6 +205,9 @@ class Identifiers:
 	def get_whitelist(self):
 		return self.whitelist_nums
 
+	def get_self_id(self):
+		return self.self_id
+
 	# return serial number for the device this runs on
 	def get_self_serial(self):
 		return self.self_device.rb_serial
@@ -218,8 +230,8 @@ class Identifiers:
 		ground_ids = [dev["id"] for dev in self.json_obj["ground"]]
 		return (air_ids, ground_ids)
 
-	def _format_device_message(self, device):
-		pass
+	def get_valid_ids(self):
+		return self.valid_ids
 
 	# request adding a new device to admin
 	def new_device_request(self, is_air, label, number, imei, rb_serial):

--- a/ogc_ws/src/identifiers/scripts/identifiers.py
+++ b/ogc_ws/src/identifiers/scripts/identifiers.py
@@ -135,16 +135,6 @@ class Identifiers:
 
 		self.admin_id = self.json_obj["admin"]["telegram_id"]
 
-	# callback function for the topic subscriber class
-	# used to add contacts to telegram after the telegram node has subscribed to the topic
-	def request_telegram_id(self):
-		# rospy.loginfo("Telegram link has subscribed to contact topic")
-		print("Telegram link has subscribed to contact topic")
-		# loop through list of unknown devices
-		while self.telegram_unknown_ids:
-			contact = self.telegram_unknown_ids.pop(0)		# removed item from list as it wont be needed anymore
-			self.update_telegram_id(contact[0], contact[1])	# request telegram to add the information to a new contact
-
 	# return the device associated with the id from whitelisted devices
 	def get_device(self, id_n):
 		for device in self.whitelist:
@@ -173,12 +163,7 @@ class Identifiers:
 		if device is None:
 			return None
 		
-		# check if device has the telegram id available, if not available, try to add it
 		telegram_id = device.telegram_id
-		if telegram_id is None:
-			self.update_telegram_id(device.label, device.number)
-			return None
-
 		return telegram_id
 
 	# return the telegram_id of the admin account

--- a/ogc_ws/src/identifiers/scripts/identifiers.py
+++ b/ogc_ws/src/identifiers/scripts/identifiers.py
@@ -97,8 +97,10 @@ class Identifiers:
 		if self.admin:
 			for obj in self.json_obj['ground']:
 				self.whitelist_telegram_ids.append(str(obj['telegram_id']))
+				self.ground_devices.append(Device(obj['label'], False, obj['id'], obj['number'], obj['imei'], obj['rb_serial'], obj['telegram_id']))
 			for obj in self.json_obj['air']:
 				self.whitelist_telegram_ids.append(str(obj['telegram_id']))
+				self.air_devices.append(Device(obj['label'], True, obj['id'], obj['number'], obj['imei'], obj['rb_serial'], obj['telegram_id']))
 
 		# Search file for all devices without a telegram user id
 		for obj in self.json_obj["ground"] + self.json_obj["air"]:

--- a/ogc_ws/src/identifiers/scripts/identifiers.py
+++ b/ogc_ws/src/identifiers/scripts/identifiers.py
@@ -67,6 +67,8 @@ class Identifiers:
 		self.svr_ip = ""					# ip address of hosted web server
 		self.admin_id = 0
 
+		self.air_devices = []
+		self.ground_devices = []
 		# instance of the class to keep track of subscribers to a topic
 		# topic_cb = TopicSubscriberNotification(self.request_telegram_id)
 
@@ -118,9 +120,12 @@ class Identifiers:
 		# Runs on admin instance
 		if self.self_id == 0:
 			for obj in self.json_obj["ground"]:
-				# self.whitelist.append(Device(obj["label"], self.is_air, obj["id"], obj["number"], obj["imei"], obj["rb_serial"], obj.get("telegram_id", None)))
+				self.ground_devices.append(Device(obj["label"], self.is_air, obj["id"], obj["number"], obj["imei"], obj["rb_serial"], obj.get("telegram_id", None)))
 				if "telegram_id" in obj.keys():
 					self.whitelist_telegram_ids.append(str(obj["telegram_id"]))
+			for obj in self.json_obj['air']:
+				self.air_devices.append(Device(obj["label"], self.is_air, obj["id"], obj["number"], obj["imei"], obj["rb_serial"], obj.get("telegram_id", None)))
+	
 		# for standalone numbers (not currently in use)
 		for num in self.json_obj["standalone"]:
 			self.whitelist_nums.append(num)
@@ -212,6 +217,11 @@ class Identifiers:
 
 	def get_self_number(self):
 		return self.device.number
+
+	def get_air_telegram_id(self, id_n):
+		for device in self.air_devices:
+			if device.id == id_n:
+				return device.telegram_id
 
 	# return all the id numbers currently in use (device exists in identifiers file)
 	def get_active_ids(self):

--- a/ogc_ws/src/identifiers/scripts/identifiers.py
+++ b/ogc_ws/src/identifiers/scripts/identifiers.py
@@ -280,7 +280,7 @@ class Identifiers:
 
 		# get the telegram user id
 		# self.update_telegram_id(label, number)
-		return True
+		return selected_id
 
 
 	# edit an existing device in the identifiers file

--- a/ogc_ws/src/identifiers/scripts/identifiers.py
+++ b/ogc_ws/src/identifiers/scripts/identifiers.py
@@ -35,6 +35,7 @@ class Identifiers:
 		# self.self_id = self_id 				# id number as defined in the identifiers file of the device this runs on
 		self.self_device = None				# Information about the device this runs one
 		self.valid_ids = []					# List of whitelisted ids as defined the identifiers file
+		self.admin = False
 
 		# read valid ids from the valid_ids file
 		if valid_ids_file:
@@ -46,6 +47,8 @@ class Identifiers:
 				print("Valid ids file is not available")
 				print("please check that the telegram_bone script works properly")
 				exit()
+		else:
+			self.admin = True
 
 		try:
 			with open(self_id_file, "r") as f:
@@ -68,9 +71,6 @@ class Identifiers:
 
 		self.air_devices = []
 		self.ground_devices = []
-
-		# topic publisher to the telegram node to add contacts
-		# self.telegram_unknown_ids = []		# List of unknown telegram users (contains tuple of the form (label, numer))
 
 		# parse the identifiers file
 		self._parse_file()
@@ -114,14 +114,12 @@ class Identifiers:
 				break
 
 		# Runs on admin instance
-		if self.self_id == 0:
-			for obj in self.json_obj["ground"]:
-				self.ground_devices.append(Device(obj["label"], self.is_air, obj["id"], obj["number"], obj["imei"], obj["rb_serial"], obj.get("telegram_id", None)))
-				if "telegram_id" in obj.keys():
-					self.whitelist_telegram_ids.append(str(obj["telegram_id"]))
+		if self.admin:
+			for obj in self.json_obj['ground']:
+				self.whitelist_telegram_ids.append(str(obj['telegram_id']))
 			for obj in self.json_obj['air']:
-				self.air_devices.append(Device(obj["label"], self.is_air, obj["id"], obj["number"], obj["imei"], obj["rb_serial"], obj.get("telegram_id", None)))
-	
+				self.whitelist_telegram_ids.append(str(obj['telegram_id']))
+
 		# for standalone numbers (not currently in use)
 		for num in self.json_obj["standalone"]:
 			self.whitelist_nums.append(num)

--- a/ogc_ws/src/identifiers/scripts/identifiers.py
+++ b/ogc_ws/src/identifiers/scripts/identifiers.py
@@ -227,6 +227,7 @@ class Identifiers:
 		device = {
 			"request": "add",
 			"label": label,
+			"is_air": is_air,
 			"number": number,
 			"imei": imei,
 			"rb_serial": rb_serial
@@ -239,6 +240,7 @@ class Identifiers:
 			"request": "edit",
 			"label": label,
 			"id": id_n,
+			"is_air": is_air,
 			"number": number,
 			"imei": imei,
 			"rb_serial": rb_serial
@@ -263,7 +265,7 @@ class Identifiers:
 
 		edit_list.append({
 			"label": device["label"],
-			"id": device["selected_id"],
+			"id": selected_id,
 			"number": device["number"],
 			"imei": device["imei"],
 			"rb_serial": device["rb_serial"],
@@ -277,7 +279,7 @@ class Identifiers:
 		self._parse_file()
 
 		# get the telegram user id
-		self.update_telegram_id(label, number)
+		# self.update_telegram_id(label, number)
 		return True
 
 
@@ -289,7 +291,7 @@ class Identifiers:
 		# find the correct object for the id
 		selected_device = None
 		for dev in edit_list:
-			if dev["id"] == id_n:
+			if dev["id"] == device['id']:
 				selected_device = dev
 				break
 

--- a/ogc_ws/src/identifiers/scripts/identifiers.py
+++ b/ogc_ws/src/identifiers/scripts/identifiers.py
@@ -32,7 +32,7 @@ class Identifiers:
 	def __init__(self, json_file, is_air, self_id_file, valid_ids_file):
 		self.json_file = json_file			# Location of identifiers file
 		self.is_air = is_air				# Boolean to know if it is running air side or ground side
-		# self.self_id = self_id 				# id number as defined in the identifiers file of the device this runs on
+		self.self_id = 0	 				# id number as defined in the identifiers file of the device this runs on
 		self.self_device = None				# Information about the device this runs one
 		self.valid_ids = []					# List of whitelisted ids as defined the identifiers file
 		self.admin = False
@@ -50,7 +50,7 @@ class Identifiers:
 		else:
 			self.admin = True
 
-		if not admin:
+		if not self.admin:
 			try:
 				with open(self_id_file, "r") as f:
 					self.self_id = int(f.readline().rstrip())
@@ -93,6 +93,13 @@ class Identifiers:
 		self.whitelist_rb_serial.clear()
 		self.whitelist_telegram_ids.clear()
 
+		# Runs on admin instance
+		if self.admin:
+			for obj in self.json_obj['ground']:
+				self.whitelist_telegram_ids.append(str(obj['telegram_id']))
+			for obj in self.json_obj['air']:
+				self.whitelist_telegram_ids.append(str(obj['telegram_id']))
+
 		# Search file for all devices without a telegram user id
 		for obj in self.json_obj["ground"] + self.json_obj["air"]:
 			if "telegram_id" not in obj.keys():
@@ -113,13 +120,6 @@ class Identifiers:
 			if obj["id"] == self.self_id:
 				self.self_device = Device(obj["label"], self.is_air, obj["id"], obj["number"], obj["imei"], obj["rb_serial"], obj.get("telegram_id", None))
 				break
-
-		# Runs on admin instance
-		if self.admin:
-			for obj in self.json_obj['ground']:
-				self.whitelist_telegram_ids.append(str(obj['telegram_id']))
-			for obj in self.json_obj['air']:
-				self.whitelist_telegram_ids.append(str(obj['telegram_id']))
 
 		# for standalone numbers (not currently in use)
 		for num in self.json_obj["standalone"]:

--- a/ogc_ws/src/identifiers/scripts/identifiers.py
+++ b/ogc_ws/src/identifiers/scripts/identifiers.py
@@ -16,9 +16,6 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import json
-# import rospy
-
-# from telegram.msg import ContactInfo
 
 # helper class to hold information about the devices specified in the identifiers file
 class Device:
@@ -31,23 +28,6 @@ class Device:
 		self.rb_serial = rb_serial
 		self.telegram_id = telegram_id
 
-# Class to keep track of subscriptions to any topic when publishing
-# class TopicSubscriberNotification:
-# 	def __init__(self, callback):
-# 		self.callback = callback	# the callback function that will be called when the subscriber count is 1
-# 		self.subscriber_count = 0
-
-# 	def peer_subscribe(self, topic_name, topic_publish, peer_publish):
-# 		rospy.loginfo("SUBSCRIBED to %s", topic_name)
-# 		self.subscriber_count += 1
-# 		if self.subscriber_count == 1:
-# 			self.callback()
-
-# 	def peer_unsubscribe(self, topic_name, num_peers):
-# 		rospy.loginfo("UNSUBSCRIBED from %s", topic_name)
-# 		self.subscriber_count -= 1
-
-
 class Identifiers:
 	def __init__(self, json_file, is_air, self_id, valid_ids_file):
 		self.json_file = json_file			# Location of identifiers file
@@ -56,6 +36,7 @@ class Identifiers:
 		self.self_device = None				# Information about the device this runs one
 		self.valid_ids = []					# List of whitelisted ids as defined the identifiers file
 
+		# read valid ids from the valid_ids file
 		with open(valid_ids_file, "r") as f:
 			while valid_id := f.readline():
 				self.valid_ids.append(int(valid_id))
@@ -73,12 +54,9 @@ class Identifiers:
 
 		self.air_devices = []
 		self.ground_devices = []
-		# instance of the class to keep track of subscribers to a topic
-		# topic_cb = TopicSubscriberNotification(self.request_telegram_id)
 
 		# topic publisher to the telegram node to add contacts
-		# self.telegram_add_contact = rospy.Publisher('ogc/to_telegram/contact', ContactInfo, queue_size=10, subscriber_listener=topic_cb)
-		self.telegram_unknown_ids = []		# List of unknown telegram users (contains tuple of the form (label, numer))
+		# self.telegram_unknown_ids = []		# List of unknown telegram users (contains tuple of the form (label, numer))
 
 		# parse the identifiers file
 		self._parse_file()
@@ -188,6 +166,7 @@ class Identifiers:
 
 		return telegram_id
 
+	# return the telegram_id of the admin account
 	def get_admin_id(self):
 		return self.admin_id
 
@@ -292,8 +271,6 @@ class Identifiers:
 
 		self._parse_file()
 
-		# get the telegram user id
-		# self.update_telegram_id(label, number)
 		return selected_id
 
 
@@ -326,58 +303,7 @@ class Identifiers:
 
 		self._parse_file()
 
-		# add the new number to telegram if number changed
-		# if number != "":
-			# self.update_telegram_id(selected_device["label"], selected_device["number"])
 		return True
-
-	# write the telegram user id for a device into the identifiers file
-	# def add_telegram_id(self, number, telegram_id):
-	# 	# edit objects in both air and ground if it exists in both (mainly needed in testing, unlikely to be needed in ops)
-	# 	obj_edited = False
-	# 	for device in self.json_obj["air"]:
-	# 		if device["number"] == number:
-	# 			if device.get("telegram_id", 0) != telegram_id:
-	# 				device["telegram_id"] = telegram_id
-	# 				obj_edited = True
-	# 				break
-
-	# 	for device in self.json_obj["ground"]:
-	# 		if device["number"] == number:
-	# 			if device.get("telegram_id", 0) != telegram_id:
-	# 				device["telegram_id"] = telegram_id
-	# 				obj_edited = True
-	# 				break
-
-	# 	if not obj_edited:
-	# 		return False
-
-	# 	# rospy.loginfo("Adding telegram id %s to number %s", telegram_id, number)
-	# 	print(f"Adding telegram id {telegram_id} to number {number}")
-
-	# 	with open(self.json_file, "w") as f:
-	# 		json.dump(self.json_obj, f)
-
-	# 	self._parse_file()
-	# 	return True
-
-	# request telegram to add contact and get the user id
-	# def update_telegram_id(self, label, number):
-	# 	# rospy.loginfo("requesting telegram_id for %s (%s)", label, number)
-	# 	print(f"requesting telegram_id for {label} ({number})", label, number)
-	# 	# contact = ContactInfo()
-	# 	contact.label = label
-	# 	contact.number = number
-		
-	# 	# check if the number is for the telegram account itself
-	# 	# it is not possible to add a contact of yourself in telegram
-	# 	if number == self.self_device.number:
-	# 		contact.me = True
-	# 	else:
-	# 		contact.me = False
-
-	# 	self.telegram_add_contact.publish(contact)
-
 
 	# Does a lazy check to see if the received message is from a valid sender
 	# Trusts that the sender of the message was correctly identified in the message headers

--- a/ogc_ws/src/identifiers/scripts/identifiers.py
+++ b/ogc_ws/src/identifiers/scripts/identifiers.py
@@ -37,9 +37,15 @@ class Identifiers:
 		self.valid_ids = []					# List of whitelisted ids as defined the identifiers file
 
 		# read valid ids from the valid_ids file
-		with open(valid_ids_file, "r") as f:
-			while valid_id := f.readline():
-				self.valid_ids.append(int(valid_id))
+		if valid_ids_file:
+			try:
+				with open(valid_ids_file, "r") as f:
+					while valid_id := f.readline():
+						self.valid_ids.append(int(valid_id))
+			except FileNotFoundError:
+				print("Valid ids file is not available")
+				print("please check that the telegram_bone script works properly")
+				exit()
 
 		self.whitelist = []					# List of whitelisted devices (contains instances of the Device class)
 		self.whitelist_nums = []			# List of whitelisted numbers (contains phone number of the whitelisted devices)

--- a/ogc_ws/src/identifiers/scripts/identifiers.py
+++ b/ogc_ws/src/identifiers/scripts/identifiers.py
@@ -50,7 +50,6 @@ class Identifiers:
 		try:
 			with open(self_id_file, "r") as f:
 				self.self_id = int(f.readline().rstrip())
-				print(self.self_id)
 		except FileNotFoundError:
 			print("seld_id file is not available")
 			print("Please ensure the device was properly set up")

--- a/ogc_ws/src/identifiers/scripts/identifiers.py
+++ b/ogc_ws/src/identifiers/scripts/identifiers.py
@@ -49,12 +49,16 @@ class Device:
 
 
 class Identifiers:
-	def __init__(self, json_file, is_air, self_id, valid_ids):
+	def __init__(self, json_file, is_air, self_id, valid_ids_file):
 		self.json_file = json_file			# Location of identifiers file
 		self.is_air = is_air				# Boolean to know if it is running air side or ground side
 		self.self_id = self_id 				# id number as defined in the identifiers file of the device this runs on
-		self.valid_ids = valid_ids			# List of whitelisted ids as defined the identifiers file
 		self.self_device = None				# Information about the device this runs one
+		self.valid_ids = []					# List of whitelisted ids as defined the identifiers file
+
+		with open(valid_ids_file, "r") as f:
+			while valid_id := f.readline():
+				self.valid_ids.append(int(valid_id))
 
 		self.whitelist = []					# List of whitelisted devices (contains instances of the Device class)
 		self.whitelist_nums = []			# List of whitelisted numbers (contains phone number of the whitelisted devices)

--- a/ogc_ws/src/identifiers/src/identifiers_server
+++ b/ogc_ws/src/identifiers/src/identifiers_server
@@ -56,6 +56,9 @@ class ServiceHandler:
 		else:
 			return None
 
+	def get_self_id(self, request):
+		return GetSelfDetailsResponse(data_int=self._ids.get_self_id())
+
 	def get_self_imei(self, request):
 		return GetSelfDetailsResponse(data=self._ids.get_self_imei())
 
@@ -66,6 +69,9 @@ class ServiceHandler:
 		username, password, svr_hostname, svr_ip = self._ids.get_sbd_credentials()
 		return GetSBDDetailsResponse(username=username, password=password, svr_hostname=svr_hostname,\
 			svr_ip=svr_ip)
+
+	def get_valid_ids(self, request):
+		return GetIdsResponse(ids=self._ids.get_valid_ids())
 
 	def add_new_device(self, request):
 		device= self._ids.new_device_request(label=request.label, is_air=request.is_air, number=request.number, imei=request.imei, rb_serial=request.rb_serial)
@@ -101,10 +107,10 @@ if __name__ == '__main__':
 	rospy.init_node("identifiers_server", anonymous=False, disable_signals=True)
 	identifiers_file = rospy.get_param("~identifiers_file")
 	is_air = rospy.get_param("~is_air")
-	self_id = rospy.get_param("~self_id")
-	valid_ids = rospy.get_param("~valid_ids")
+	self_id_file = rospy.get_param("~self_id_file")
+	valid_ids_file = rospy.get_param("~valid_ids_file")
 
-	handler = ServiceHandler(identifiers_file, is_air, self_id, valid_ids)
+	handler = ServiceHandler(identifiers_file, is_air, self_id_file, valid_ids_file)
 
 	number_service = rospy.Service("identifiers/get/number", GetDetails, handler.get_phone_number)
 	imei_service = rospy.Service("identifiers/get/imei", GetDetails, handler.get_imei)
@@ -112,9 +118,11 @@ if __name__ == '__main__':
 	active_ids_service = rospy.Service("identifiers/get/ids", GetIds, handler.get_ids)
 	telegram_id_service = rospy.Service("identifiers/get/telegram_id", GetDetails, handler.get_telegram_id)
 	admin_id_service = rospy.Service("identifiers/get/admin_id", GetDetails, handler.get_admin_id)
+	valid_ids_servuce = rospy.Service("identifiers/get/valid_ids", GetIds, handler.get_valid_ids)
 
 	device_service = rospy.Service("identifiers/get/all", GetAllDetails, handler.get_device_details)
 
+	self_id_service = rospy.Service("identifiers/self/self_id", GetSelfDetails, handler.get_self_id)
 	self_imei_service = rospy.Service("identifiers/self/imei", GetSelfDetails, handler.get_self_imei)
 	self_serial_service = rospy.Service("identifiers/self/serial", GetSelfDetails, handler.get_self_serial)
 	sbd_details_service = rospy.Service("identifiers/self/sbd", GetSBDDetails, handler.get_sbd_details)

--- a/ogc_ws/src/identifiers/src/identifiers_server
+++ b/ogc_ws/src/identifiers/src/identifiers_server
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import rospy
+from std_msgs.msg import String
 
 from identifiers import Identifiers
 from identifiers.srv import GetDetails, GetDetailsResponse
@@ -31,6 +32,7 @@ from identifiers.srv import GetIds, GetIdsResponse
 class ServiceHandler:
 	def __init__(self, identifiers_file, is_air, self_id, valid_ids):
 		self._ids = Identifiers(identifiers_file, is_air, self_id, valid_ids)
+		self.telegram_pub = rospy.Publisher('ogc/to_telegram/admin', String, queue_size=10)
 
 	def get_phone_number(self, request):
 		return GetDetailsResponse(data=self._ids.get_number(request.id))
@@ -43,6 +45,9 @@ class ServiceHandler:
 
 	def get_telegram_id(self, request):
 		return GetDetailsResponse(data_int=self._ids.get_telegram_id(request.id))
+
+	def get_admin_id(self, request):
+		return GetDetailsResponse(data_int=self._ids.get_admin_id())
 
 	def get_device_details(self, request):
 		device = self._ids.get_device_details(request.id, request.is_air)
@@ -63,18 +68,16 @@ class ServiceHandler:
 			svr_ip=svr_ip)
 
 	def add_new_device(self, request):
-		result = self._ids.add_new_device(label=request.label, is_air=request.is_air, number=request.number, imei=request.imei, rb_serial=request.rb_serial)
-		if not result:
-			rospy.logwarn("Failed to add information to identifiers file")
+		device= self._ids.new_device_request(label=request.label, is_air=request.is_air, number=request.number, imei=request.imei, rb_serial=request.rb_serial)
+		self.telegram_pub.publish(device)
 
-		return AddNewDeviceResponse(result)
+		return AddNewDeviceResponse(True)
 
 	def edit_device(self, request):
-		result = self._ids.edit_device(request.id, request.is_air, label=request.label, number=request.number, imei=request.imei, rb_serial=request.rb_serial)
-		if not result:
-			rospy.logwarn("Failed to edit device in identifiers_file")
+		device= self._ids.edit_device_request(request.id, request.is_air, label=request.label, number=request.number, imei=request.imei, rb_serial=request.rb_serial)
+		self.telegram_pub.publish(device)
 
-		return EditDeviceResponse(result)
+		return EditDeviceResponse(True)
 
 	def add_telegram_id(self, request):
 		return AddTelegramIdResponse(self._ids.add_telegram_id(request.number, request.telegram_id))
@@ -108,6 +111,7 @@ if __name__ == '__main__':
 	serial_service = rospy.Service("identifiers/get/serial", GetDetails, handler.get_serial)
 	active_ids_service = rospy.Service("identifiers/get/ids", GetIds, handler.get_ids)
 	telegram_id_service = rospy.Service("identifiers/get/telegram_id", GetDetails, handler.get_telegram_id)
+	admin_id_service = rospy.Service("identifiers/get/admin_id", GetDetails, handler.get_admin_id)
 
 	device_service = rospy.Service("identifiers/get/all", GetAllDetails, handler.get_device_details)
 

--- a/ogc_ws/src/identifiers/srv/GetIds.srv
+++ b/ogc_ws/src/identifiers/srv/GetIds.srv
@@ -1,3 +1,4 @@
 ---
 uint8[] air_ids
 uint8[] ground_ids
+uint8[] ids

--- a/ogc_ws/src/identifiers/srv/GetSelfDetails.srv
+++ b/ogc_ws/src/identifiers/srv/GetSelfDetails.srv
@@ -1,2 +1,3 @@
 ---
 string data
+uint8 data_int

--- a/ogc_ws/src/sbd/src/sbd_gnd_link.py
+++ b/ogc_ws/src/sbd/src/sbd_gnd_link.py
@@ -31,7 +31,7 @@ import struct
 import rospy
 from std_msgs.msg import String
 from despatcher.msg import LinkMessage
-from identifiers.srv import GetDetails, CheckSender, GetSBDDetails, GetIds
+from identifiers.srv import GetDetails, CheckSender, GetSBDDetails, GetIds, GetSelfDetails
 
 # Local
 from sbd_air_link import satcomms
@@ -50,6 +50,7 @@ class satcommsgnd(satcomms):
         rospy.wait_for_service("identifiers/get/imei")
         rospy.wait_for_service("identifiers/self/sbd")
         rospy.wait_for_service("identifiers/check/proper")
+        rospy.wait_for_service("identifiers/self/self_id")
 
         self._get_ids = rospy.ServiceProxy("identifiers/get/ids", GetIds)
         self._get_imei = rospy.ServiceProxy("identifiers/get/imei", GetDetails)
@@ -58,9 +59,11 @@ class satcommsgnd(satcomms):
 
         self._init_variables()
 
+        ids_get_self_id = rospy.ServiceProxy("identifiers/self/self_id", GetSelfDetails)
+        self._id = ids_get_self_id().data_int # Our GCS ID
+
         # Switch state: Temporary state where gnd node is switching between server and ground rockblock
         self._switch_state = False # True = switch state is active
-        self._id = rospy.get_param("~self_id") # Our GCS ID
         self._is_air = 0 # We are a ground node!
 
         # Three least significant bytes of own serial, used for binary unpack of regular payload

--- a/ogc_ws/src/telegram/launch/telegram_air.launch
+++ b/ogc_ws/src/telegram/launch/telegram_air.launch
@@ -17,13 +17,15 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 
 <launch>
-	<arg name="tdlib_auth_dir" default="$(env HOME)/.tdlib"/>
+	<arg name="tdlib_auth_dir" default="$(env HOME)/.tdlib_air"/>
 	<arg name="log_output" default="screen"/>
 
 
-	<arg name="identifiers_file"  default="$(env HOME)/identifiers.json" />
-	<arg name="ground_ids" default="[1]" />
-	<arg name="self_id" default="2" />
+	<arg name="identifiers_file"  default="$(env HOME)/Sync/identifiers.json" />
+	<arg name="valid_ids_file" default="$(env HOME)/.valid_ids" />
+	<arg name="self_id_file" default="$(env HOME)/.self_id" />
+	<!-- <arg name="ground_ids" default="[1]" /> -->
+	<!-- <arg name="self_id" default="2" /> -->
 	<arg name="is_air" default="True" />
 	<arg name="link_select" default="0" />
 	<arg name="waypoint_folder" default="$(env HOME)/Waypoints/"/>
@@ -34,22 +36,21 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 	<node pkg="telegram" type="telegram_link" name="telegram_link" respawn="true" respawn_delay="3" output="$(arg log_output)" >
 		<param name="tdlib_auth_dir" value="$(arg tdlib_auth_dir)" />
-		<rosparam param="valid_ids" subst_value="True">$(arg ground_ids)</rosparam>
+		<!-- <rosparam param="valid_ids" subst_value="True">$(arg ground_ids)</rosparam> -->
 	</node>
 
 	<node pkg="identifiers" type="identifiers_server" name="identifiers_server" respawn="true" respawn_delay="3" output="$(arg log_output)" >
 		<param name="identifiers_file" value="$(arg identifiers_file)" />
 		<param name="is_air" value="$(arg is_air)" />
-		<param name="self_id" value="$(arg self_id)" />
-		<rosparam param="valid_ids" subst_value="True">$(arg ground_ids)</rosparam>
+		<param name="self_id_file" value="$(arg self_id_file)" />
+		<param name="valid_ids_file" value="$(arg valid_ids_file)" />
+		<!-- <rosparam param="valid_ids_file" subst_value="True">$(arg ground_ids)</rosparam> -->
 	</node>		
 
 	<!-- air despatcher node -->
 	<node pkg="despatcher" type="air_despatcher.py" name="air_despatcher" respawn="true" respawn_delay="3" output="$(arg log_output)">
-		<rosparam param="ground_ids" subst_value="True">$(arg ground_ids)</rosparam>
 		<param name="interval_1" value="$(arg interval_1)" />
 		<param name="interval_2" value="$(arg interval_2)" />
-		<param name="self_id" value="$(arg self_id)" />
 		<param name="link_select" value="$(arg link_select)" />
 		<param name="waypoint_folder" value="$(arg waypoint_folder)"/>
 	</node>

--- a/ogc_ws/src/telegram/launch/telegram_air.launch
+++ b/ogc_ws/src/telegram/launch/telegram_air.launch
@@ -36,7 +36,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 	<node pkg="telegram" type="telegram_link" name="telegram_link" respawn="true" respawn_delay="3" output="$(arg log_output)" >
 		<param name="tdlib_auth_dir" value="$(arg tdlib_auth_dir)" />
-		<!-- <rosparam param="valid_ids" subst_value="True">$(arg ground_ids)</rosparam> -->
 	</node>
 
 	<node pkg="identifiers" type="identifiers_server" name="identifiers_server" respawn="true" respawn_delay="3" output="$(arg log_output)" >
@@ -44,7 +43,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 		<param name="is_air" value="$(arg is_air)" />
 		<param name="self_id_file" value="$(arg self_id_file)" />
 		<param name="valid_ids_file" value="$(arg valid_ids_file)" />
-		<!-- <rosparam param="valid_ids_file" subst_value="True">$(arg ground_ids)</rosparam> -->
 	</node>		
 
 	<!-- air despatcher node -->

--- a/ogc_ws/src/telegram/launch/telegram_air.launch
+++ b/ogc_ws/src/telegram/launch/telegram_air.launch
@@ -17,7 +17,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 
 <launch>
-	<arg name="tdlib_auth_dir" default="$(env HOME)/.tdlib_air"/>
+	<arg name="tdlib_auth_dir" default="$(env HOME)/.tdlib"/>
 	<arg name="log_output" default="screen"/>
 
 
@@ -26,9 +26,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	<arg name="self_id_file" default="$(env HOME)/.self_id" />
   
 	<arg name="is_air" default="True" />
-	<arg name="link_select" default="0" />
-	<arg name="waypoint_folder" default="$(env HOME)/Waypoints/"/>
-
 	<arg name="watch_dir" default="$(env HOME)/Sync" />
 	<arg name="waypoint_folder" default="$(env HOME)/Sync/Waypoints" />
 
@@ -56,7 +53,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	<node pkg="despatcher" type="air_despatcher.py" name="air_despatcher" respawn="true" respawn_delay="3" output="$(arg log_output)">
 		<param name="interval_1" value="$(arg interval_1)" />
 		<param name="interval_2" value="$(arg interval_2)" />
-		<param name="link_select" value="$(arg link_select)" />
 		<param name="waypoint_folder" value="$(arg waypoint_folder)" />
 	</node>
 </launch>

--- a/ogc_ws/src/telegram/launch/telegram_gnd.launch
+++ b/ogc_ws/src/telegram/launch/telegram_gnd.launch
@@ -17,7 +17,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 
 <launch>
-	<arg name="tdlib_auth_dir" default="$(env HOME)/.tdlib_gnd"/>
+	<arg name="tdlib_auth_dir" default="$(env HOME)/.tdlib"/>
 	<arg name="log_output" default="screen"/>
   
 	<arg name="identifiers_file" default="$(env HOME)/Sync/identifiers.json" />
@@ -25,7 +25,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	<arg name="self_id_file" default="$(env HOME)/.self_id" />
 
 	<arg name="is_air" default="False" />
-	<arg name="link_select" default="0" />
 
 	<arg name="watch_dir" default="$(env HOME)/Sync" />
 
@@ -46,7 +45,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 	<!-- ground despatcher node -->
 	<node pkg="despatcher" type="gnd_despatcher.py" name="gnd_despatcher" respawn="true" respawn_delay="3" output="$(arg log_output)">
-		<param name="link_select" value="$(arg link_select)" />
 	</node>
 	
 	<node name="yonah_rqt" pkg="rqt_gui" type="rqt_gui" respawn="true" respawn_delay="3" output="log">

--- a/ogc_ws/src/telegram/launch/telegram_gnd.launch
+++ b/ogc_ws/src/telegram/launch/telegram_gnd.launch
@@ -17,37 +17,35 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 
 <launch>
-	<arg name="tdlib_auth_dir" default="$(env HOME)/.tdlib"/>
+	<arg name="tdlib_auth_dir" default="$(env HOME)/.tdlib_gnd"/>
 	<arg name="log_output" default="screen"/>
   
-	<arg name="identifiers_file" default="$(env HOME)/identifiers.json" />
-	<arg name="air_ids" default="[1]" />
-	<arg name="self_id" default="3" />
+	<arg name="identifiers_file" default="$(env HOME)/Sync/identifiers.json" />
+	<arg name="valid_ids_file" default="$(env HOME)/.valid_ids" />
+	<arg name="self_id_file" default="$(env HOME)/.self_id" />
 	<arg name="is_air" default="False" />
 	<arg name="link_select" default="0" />
 
 
 	<node pkg="telegram" type="telegram_link" name="telegram_link" respawn="true" respawn_delay="3" output="$(arg log_output)" >
 		<param name="tdlib_auth_dir" value="$(arg tdlib_auth_dir)" />
-		<rosparam param="valid_ids" subst_value="True">$(arg air_ids)</rosparam>		
 	</node>
 
 	<node pkg="identifiers" type="identifiers_server" name="identifiers_server" respawn="true" respawn_delay="3" output="$(arg log_output)" >
 		<param name="identifiers_file" value="$(arg identifiers_file)" />
 		<param name="is_air" value="$(arg is_air)" />
-		<param name="self_id" value="$(arg self_id)" />
-		<rosparam param="valid_ids" subst_value="True">$(arg air_ids)</rosparam>
+		<param name="self_id_file" value="$(arg self_id_file)" />
+		<param name="valid_ids_file" value="$(arg valid_ids_file)" />
 	</node>	
 
 	<!-- ground despatcher node -->
 	<node pkg="despatcher" type="gnd_despatcher.py" name="gnd_despatcher" respawn="true" respawn_delay="3" output="$(arg log_output)">
-		<param name="self_id" value="$(arg self_id)" />
 		<param name="link_select" value="$(arg link_select)" />
 	</node>
 	
 	<node name="yonah_rqt" pkg="rqt_gui" type="rqt_gui" respawn="true" respawn_delay="3" output="log">
 		</node>
 
-	<node name="timeout" pkg="despatcher" type="timeout.py" respawn="true" respawn_delay="3" output="log">
-    </node>
+	<!-- <node name="timeout" pkg="despatcher" type="timeout.py" respawn="true" respawn_delay="3" output="log">
+    </node> -->
 </launch>

--- a/ogc_ws/src/telegram/scripts/Td.py
+++ b/ogc_ws/src/telegram/scripts/Td.py
@@ -198,6 +198,12 @@ class Td():
 			'priority': 1,
 		})
 
+	def create_chat(self, user_id):
+		self.send({
+			'@type': 'createPrivateChat',
+			'user_id': user_id
+		})
+
 	# receive information from telegram
 	def receive(self):
 		result_orig = self._client_receive(self.client, 1.0)

--- a/ogc_ws/src/telegram/src/telegram_admin
+++ b/ogc_ws/src/telegram/src/telegram_admin
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2020 Rumesh Sudhaharan
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from threading import Thread
+from pathlib import Path
+import json
+
+from Td import Td
+from identifiers import Identifiers
+
+home_dir = str(Path.home())
+tdlib_dir = home_dir + '/.tdlib_air'
+identifiers_file = home_dir + '/Sync/identifiers.json'
+self_id = 0
+valid_ids = []
+
+if __name__ == '__main__':
+	td = Td(tdlib_dir)
+	ids = Identifiers(identifiers_file, False, self_id, valid_ids)
+
+
+	while True:
+		event = td.receive()
+		if event:
+			if event['@type'] == 'error':
+				print(f"[ERROR] {json.dumps(event)}")
+				td.get_chats()
+
+			if event['@type'] == 'updateNewMessage':
+				if event['message']['is_outgoing']:
+					continue
+
+				is_valid_sender = ids.is_valid_sender(0, str(event['message']['sender_user_id']))
+				if not is_valid_sender:
+					print("message from invalid user")
+					continue
+
+				msg = event['message']['content']['text']['text']
+				print(f"New Message: {msg}")
+				td.set_read(event['message']['chat_id'], event['message']['id'])
+				try:
+					msg_json = json.loads(msg)
+					print(msg_json)
+					print("----")
+					print(f'label: {msg_json["label"]}')
+					# print(f'id: {msg_json["id"]}')
+					print(f'number: {msg_json["number"]}')
+					print(f'imei: {msg_json["imei"]}')
+					print(f'rb_serial: {msg_json["rb_serial"]}')
+				except json.JSONDecodeError:
+					print('invalid message format')
+					continue

--- a/ogc_ws/src/telegram/src/telegram_admin
+++ b/ogc_ws/src/telegram/src/telegram_admin
@@ -18,6 +18,7 @@
 from threading import Thread
 from pathlib import Path
 import json
+import time
 
 from Td import Td
 from identifiers import Identifiers
@@ -31,7 +32,9 @@ valid_ids = []
 if __name__ == '__main__':
 	td = Td(tdlib_dir)
 	ids = Identifiers(identifiers_file, False, self_id, valid_ids)
+	boot_time = time.time()
 
+	id_waitlist = {}
 
 	while True:
 		event = td.receive()
@@ -41,7 +44,7 @@ if __name__ == '__main__':
 				td.get_chats()
 
 			if event['@type'] == 'updateNewMessage':
-				if event['message']['is_outgoing']:
+				if event['message']['is_outgoing'] or event['message']['date'] < boot_time:
 					continue
 
 				is_valid_sender = ids.is_valid_sender(0, str(event['message']['sender_user_id']))
@@ -54,13 +57,27 @@ if __name__ == '__main__':
 				td.set_read(event['message']['chat_id'], event['message']['id'])
 				try:
 					msg_json = json.loads(msg)
+
 					print(msg_json)
-					print("----")
-					print(f'label: {msg_json["label"]}')
-					# print(f'id: {msg_json["id"]}')
-					print(f'number: {msg_json["number"]}')
-					print(f'imei: {msg_json["imei"]}')
-					print(f'rb_serial: {msg_json["rb_serial"]}')
+					print(f"adding contact {msg_json['number']} {msg_json['label']} ")
+
+					id_waitlist[msg_json['number']] = msg_json
+					td.add_contact(msg_json['number'], msg_json['label'])
+					td.get_contacts()
 				except json.JSONDecodeError:
 					print('invalid message format')
 					continue
+
+			if event['@type'] == 'user':
+				dev = id_waitlist.pop(event['phone_number'], None)
+				if not dev:
+					continue
+
+				print(f"Got id {event['id']} for {event['phone_number']}")
+				dev['telegram_id'] = event['id']
+
+				if dev['request'] == 'add':
+					ids.add_new_device(dev)
+				elif dev['request'] == 'edit':
+					ids.edit_device(dev)
+					

--- a/ogc_ws/src/telegram/src/telegram_admin
+++ b/ogc_ws/src/telegram/src/telegram_admin
@@ -25,12 +25,12 @@ from identifiers import Identifiers
 home_dir = str(Path.home())
 tdlib_dir = home_dir + '/.tdlib_admin'
 identifiers_file = home_dir + '/Sync/identifiers.json'
-self_id = 0
+self_id = home_dir + '/.self_id'
 # valid_ids_file = home_dir + '/.valid_ids'
 
 if __name__ == '__main__':
 	td = Td(tdlib_dir)
-	ids = Identifiers(identifiers_file, False, self_id, None)
+	ids = Identifiers(identifiers_file, True, self_id, None)
 	boot_time = time.time()
 
 	id_waitlist = {}
@@ -73,6 +73,7 @@ if __name__ == '__main__':
 
 						id_waitlist[msg_json['number']] = msg_json
 						td.add_contact(msg_json['number'], msg_json['label'])
+						time.sleep(1)
 						td.get_contacts()
 				except json.JSONDecodeError:
 					print('invalid message format')
@@ -98,4 +99,5 @@ if __name__ == '__main__':
 						"request": "set_device_id",
 						"device_id": dev_id
 					}
+					td.create_chat(event['id'])
 					td.send_message(event['id'], json.dumps(msg))

--- a/ogc_ws/src/telegram/src/telegram_admin
+++ b/ogc_ws/src/telegram/src/telegram_admin
@@ -23,7 +23,7 @@ from Td import Td
 from identifiers import Identifiers
 
 home_dir = str(Path.home())
-tdlib_dir = home_dir + '/.tdlib_gnd'
+tdlib_dir = home_dir + '/.tdlib_admin'
 identifiers_file = home_dir + '/Sync/identifiers.json'
 self_id = 0
 valid_ids_file = home_dir + '/.valid_ids'
@@ -66,7 +66,6 @@ if __name__ == '__main__':
 								'request': 'set_gcs_id',
 								'ground_ids': msg_json['ground_ids']
 							}
-							print(json.dumps(command_msg))
 							td.send_message(telegram_id, json.dumps(command_msg))
 					elif msg_json['request'] in ['add','edit']:
 						print(msg_json)
@@ -96,7 +95,7 @@ if __name__ == '__main__':
 
 				if dev['is_air']:
 					msg = {
-						"action": "set_device_id",
+						"request": "set_device_id",
 						"device_id": dev_id
 					}
 					td.send_message(event['id'], json.dumps(msg))

--- a/ogc_ws/src/telegram/src/telegram_admin
+++ b/ogc_ws/src/telegram/src/telegram_admin
@@ -43,7 +43,6 @@ if __name__ == '__main__':
 				td.get_chats()
 
 			if event['@type'] == 'updateNewMessage':
-				print("message received")
 				if event['message']['is_outgoing'] or event['message']['date'] < boot_time:
 					continue
 

--- a/ogc_ws/src/telegram/src/telegram_admin
+++ b/ogc_ws/src/telegram/src/telegram_admin
@@ -76,8 +76,16 @@ if __name__ == '__main__':
 				print(f"Got id {event['id']} for {event['phone_number']}")
 				dev['telegram_id'] = event['id']
 
-				if dev['request'] == 'add':
-					ids.add_new_device(dev)
-				elif dev['request'] == 'edit':
+				dev_id = 0
+				if dev.get('request') == 'add':
+					dev_id = ids.add_new_device(dev)
+				elif dev.get('request') == 'edit':
 					ids.edit_device(dev)
-					
+					dev_id = dev['id']
+
+				if dev['is_air']:
+					msg = {
+						"action": "set_device_id",
+						"device_id": dev_id
+					}
+					td.send_message(event['id'], json.dumps(msg))

--- a/ogc_ws/src/telegram/src/telegram_admin
+++ b/ogc_ws/src/telegram/src/telegram_admin
@@ -26,11 +26,11 @@ home_dir = str(Path.home())
 tdlib_dir = home_dir + '/.tdlib_gnd'
 identifiers_file = home_dir + '/Sync/identifiers.json'
 self_id = 0
-valid_ids = []
+valid_ids_file = home_dir + '/.valid_ids'
 
 if __name__ == '__main__':
 	td = Td(tdlib_dir)
-	ids = Identifiers(identifiers_file, False, self_id, valid_ids)
+	ids = Identifiers(identifiers_file, False, self_id, valid_ids_file)
 	boot_time = time.time()
 
 	id_waitlist = {}

--- a/ogc_ws/src/telegram/src/telegram_admin
+++ b/ogc_ws/src/telegram/src/telegram_admin
@@ -26,11 +26,11 @@ home_dir = str(Path.home())
 tdlib_dir = home_dir + '/.tdlib_admin'
 identifiers_file = home_dir + '/Sync/identifiers.json'
 self_id = 0
-valid_ids_file = home_dir + '/.valid_ids'
+# valid_ids_file = home_dir + '/.valid_ids'
 
 if __name__ == '__main__':
 	td = Td(tdlib_dir)
-	ids = Identifiers(identifiers_file, False, self_id, valid_ids_file)
+	ids = Identifiers(identifiers_file, False, self_id, None)
 	boot_time = time.time()
 
 	id_waitlist = {}

--- a/ogc_ws/src/telegram/src/telegram_admin
+++ b/ogc_ws/src/telegram/src/telegram_admin
@@ -15,7 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from threading import Thread
 from pathlib import Path
 import json
 import time
@@ -24,7 +23,7 @@ from Td import Td
 from identifiers import Identifiers
 
 home_dir = str(Path.home())
-tdlib_dir = home_dir + '/.tdlib_air'
+tdlib_dir = home_dir + '/.tdlib_gnd'
 identifiers_file = home_dir + '/Sync/identifiers.json'
 self_id = 0
 valid_ids = []
@@ -44,11 +43,13 @@ if __name__ == '__main__':
 				td.get_chats()
 
 			if event['@type'] == 'updateNewMessage':
+				print("message received")
 				if event['message']['is_outgoing'] or event['message']['date'] < boot_time:
 					continue
 
 				is_valid_sender = ids.is_valid_sender(0, str(event['message']['sender_user_id']))
 				if not is_valid_sender:
+					print(f"invalid sender: {event['message']['sender_user_id']}")
 					print("message from invalid user")
 					continue
 
@@ -58,12 +59,22 @@ if __name__ == '__main__':
 				try:
 					msg_json = json.loads(msg)
 
-					print(msg_json)
-					print(f"adding contact {msg_json['number']} {msg_json['label']} ")
+					if msg_json['request'] == 'set_gcs':
+						for air_id in msg_json['air_ids']:
+							telegram_id = ids.get_air_telegram_id(air_id)
+							command_msg = {
+								'request': 'set_gcs_id',
+								'ground_ids': msg_json['ground_ids']
+							}
+							print(json.dumps(command_msg))
+							td.send_message(telegram_id, json.dumps(command_msg))
+					elif msg_json['request'] in ['add','edit']:
+						print(msg_json)
+						print(f"adding contact {msg_json['number']} {msg_json['label']} ")
 
-					id_waitlist[msg_json['number']] = msg_json
-					td.add_contact(msg_json['number'], msg_json['label'])
-					td.get_contacts()
+						id_waitlist[msg_json['number']] = msg_json
+						td.add_contact(msg_json['number'], msg_json['label'])
+						td.get_contacts()
 				except json.JSONDecodeError:
 					print('invalid message format')
 					continue

--- a/ogc_ws/src/telegram/src/telegram_admin
+++ b/ogc_ws/src/telegram/src/telegram_admin
@@ -66,6 +66,7 @@ if __name__ == '__main__':
 								'request': 'set_gcs_id',
 								'ground_ids': msg_json['ground_ids']
 							}
+							td.create_chat(telegram_id)
 							td.send_message(telegram_id, json.dumps(command_msg))
 					elif msg_json['request'] in ['add','edit']:
 						print(msg_json)

--- a/ogc_ws/src/telegram/src/telegram_bone
+++ b/ogc_ws/src/telegram/src/telegram_bone
@@ -32,7 +32,7 @@ ground_ids_file = home_dir + '/.valid_ids'
 
 if __name__ == '__main__':
 	td = Td(tdlib_dir)
-	ids = Identifiers(identifiers_file, True, 0, ground_ids_file)
+	ids = Identifiers(identifiers_file, True, self_id, ground_ids_file)
 	boot_time = time.time()
 
 	admin_id = ids.get_admin_id()

--- a/ogc_ws/src/telegram/src/telegram_bone
+++ b/ogc_ws/src/telegram/src/telegram_bone
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2020 Rumesh Sudhaharan
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from pathlib import Path
+import json
+import time
+import os
+
+from Td import Td
+from identifiers import Identifiers
+
+home_dir = str(Path.home())
+tdlib_dir = home_dir + '/.tdlib_air'
+identifiers_file = home_dir + '/Sync/identifiers.json'
+self_id = 0
+valid_ids = []
+ground_ids_file = home_dir + '/.valid_ids'
+
+if __name__ == '__main__':
+	td = Td(tdlib_dir)
+	ids = Identifiers(identifiers_file, True, 0, valid_ids)
+	boot_time = time.time()
+
+	admin_id = ids.get_admin_id()
+
+	while True:
+		event = td.receive()
+		if event:
+			if event['@type'] == 'error':
+				print(f"[Error] {json.dumps(event)}")
+				td.get_chats()
+
+			if event['@type'] == 'updateNewMessage':
+				print("message received")
+				if event['message']['is_outgoing'] or event['message']['date'] < boot_time:
+					continue
+
+				td.set_read(event['message']['chat_id'], event['message']['id'])
+				msg = event['message']['content']['text']['text']
+				if event['message']['sender_user_id'] == admin_id:
+					print("is admin")
+					try:
+						msg_json = json.loads(msg)
+						if msg_json['request'] == 'set_gcs_id':
+							gcs_ids = msg_json['ground_ids']
+							with open(ground_ids_file, "w") as f:
+								for id_n in gcs_ids:
+									f.write(f"{id_n}\n")
+							exit()
+					except json.JSONDecodeError:
+						print('invalid message format')
+						continue

--- a/ogc_ws/src/telegram/src/telegram_bone
+++ b/ogc_ws/src/telegram/src/telegram_bone
@@ -27,12 +27,12 @@ home_dir = str(Path.home())
 tdlib_dir = home_dir + '/.tdlib_air'
 identifiers_file = home_dir + '/Sync/identifiers.json'
 self_id = 0
-valid_ids = []
+# valid_ids_file = 
 ground_ids_file = home_dir + '/.valid_ids'
 
 if __name__ == '__main__':
 	td = Td(tdlib_dir)
-	ids = Identifiers(identifiers_file, True, 0, valid_ids)
+	ids = Identifiers(identifiers_file, True, 0, ground_ids_file)
 	boot_time = time.time()
 
 	admin_id = ids.get_admin_id()

--- a/ogc_ws/src/telegram/src/telegram_bone
+++ b/ogc_ws/src/telegram/src/telegram_bone
@@ -56,7 +56,7 @@ if __name__ == '__main__':
 						msg_json = json.loads(msg)
 						if msg_json['request'] == 'set_gcs_id':
 							gcs_ids = msg_json['ground_ids']
-							with open(ground_ids_file, "w") as f:
+							with open(valid_ids_file, "w") as f:
 								for id_n in gcs_ids:
 									f.write(f"{id_n}\n")
 							exit()

--- a/ogc_ws/src/telegram/src/telegram_bone
+++ b/ogc_ws/src/telegram/src/telegram_bone
@@ -27,12 +27,11 @@ home_dir = str(Path.home())
 tdlib_dir = home_dir + '/.tdlib_air'
 identifiers_file = home_dir + '/Sync/identifiers.json'
 self_id = 0
-# valid_ids_file = 
-ground_ids_file = home_dir + '/.valid_ids'
+valid_ids_file = home_dir + '/.valid_ids'
 
 if __name__ == '__main__':
 	td = Td(tdlib_dir)
-	ids = Identifiers(identifiers_file, True, self_id, ground_ids_file)
+	ids = Identifiers(identifiers_file, True, self_id, None)
 	boot_time = time.time()
 
 	admin_id = ids.get_admin_id()

--- a/ogc_ws/src/telegram/src/telegram_link
+++ b/ogc_ws/src/telegram/src/telegram_link
@@ -38,7 +38,9 @@ def tdlib_topic_cb(msg, args):
 	if tele_id.data_int == 0:
 		rospy.logwarn("Invalid user id")
 	else:
-		rospy.loginfo("sending message to " + str(tele_id.data_int))
+		# rospy.loginfo("sending message to " + str(tele_id.data_int))
+		rospy.loginfo(f"sending message to {tele_id.data_int}")
+
 		td.send_message(tele_id.data_int, msg.data)
 
 # callback function run to add a contact to the telegram account
@@ -65,6 +67,12 @@ def tdlib_file_cb(msg, args):
 	home_dir = str(Path.home())
 	file_path = home_dir + "/Waypoints/" + msg.data
 	td.send_file(tele_id.data_int, file_path)
+
+def tdlib_admin_cb(msg, td):
+	get_admin_id = rospy.ServiceProxy("identifiers/get/admin_id", GetDetails)
+	admin_id = get_admin_id()
+	td.send_message(admin_id.data_int, msg.data)
+
 
 # Function to receive all messages from telegram
 # runs in a seperate thread
@@ -146,6 +154,7 @@ if __name__ == '__main__':
 		rospy.wait_for_service("identifiers/get/telegram_id")
 		rospy.wait_for_service("identifiers/add/telegram_id")
 		rospy.wait_for_service("identifiers/check/proper")
+		rospy.wait_for_service("identifiers/get/admin_id")
 
 		# Service to get the telegram user id from identifiers
 		identifiers_get_telegram_id = rospy.ServiceProxy("identifiers/get/telegram_id", GetDetails)
@@ -166,7 +175,7 @@ if __name__ == '__main__':
 		rospy.Subscriber('ogc/to_telegram', LinkMessage, tdlib_topic_cb, (td, identifiers_get_telegram_id))
 		rospy.Subscriber('ogc/to_telegram/file', LinkMessage, tdlib_file_cb, (td, identifiers_get_telegram_id))
 		rospy.Subscriber('ogc/to_telegram/contact', ContactInfo, tdlib_add_contact_cb, td)
-
+		rospy.Subscriber('ogc/to_telegram/admin', String, tdlib_admin_cb, td)
 		# inform all valid nodes that the link is up
 		# td.send_message_multi(valid_ids, ("Air" if is_air else "Ground") + " id " + str(self_id) + " Setup complete")
 

--- a/ogc_ws/src/telegram/src/telegram_link
+++ b/ogc_ws/src/telegram/src/telegram_link
@@ -41,6 +41,7 @@ def tdlib_topic_cb(msg, args):
 		# rospy.loginfo("sending message to " + str(tele_id.data_int))
 		rospy.loginfo(f"sending message to {tele_id.data_int}")
 
+		td.create_chat(tele_id.data_int)
 		td.send_message(tele_id.data_int, msg.data)
 
 # callback function run to add a contact to the telegram account

--- a/ogc_ws/src/telegram/src/telegram_link
+++ b/ogc_ws/src/telegram/src/telegram_link
@@ -148,7 +148,6 @@ if __name__ == '__main__':
 	try:
 		rospy.init_node('tele_ros', anonymous=False, disable_signals=True)
 		tdlib_dir = rospy.get_param("~tdlib_auth_dir")			# Location of the telegram account, created by the tele_auth script
-		valid_ids = rospy.get_param("~valid_ids") 				# whitelisted ids, if this is running in the air, valid_ids will only have ground ids and vice versa
 
 		# wait for required services to be available before continuing
 		rospy.wait_for_service("identifiers/get/telegram_id")

--- a/ogc_ws/src/yonah_rqt/src/yonah_rqt/command_window.py
+++ b/ogc_ws/src/yonah_rqt/src/yonah_rqt/command_window.py
@@ -522,10 +522,12 @@ class CommandWindow(QWidget):
         # Somehow get the current label inside it
         if side == "Air":
             for i in self.air_ids:
-                self.edit_combo_box.addItem("Aircraft " + chr(ord(i) + 48))
+                # self.edit_combo_box.addItem("Aircraft " + chr(ord(i) + 48))
+                self.edit_combo_box.addItem(f"Aircraft {i}")
         else:
             for i in self.ground_ids:
-                self.edit_combo_box.addItem("GCS " + chr(ord(i) + 48))
+                # self.edit_combo_box.addItem("GCS " + chr(ord(i) + 48))
+                self.edit_combo_box.addItem(f"GCS {i}")
         self.edit_combo_box.currentIndexChanged.connect(self.edit_identifiers_combo_box)
 
         self.check_validity = [0, 0, 0, 0]


### PR DESCRIPTION
Telegram now requires an admin account which will make the changes to the identifiers file

identifiers has been separated from ROS so it can be used independently for the telegram_admin script

self_id and valid_id are now stored in files and not the launch files
valid_ids can be set from rqt via the admin account so the launch file does not need to be edited directly anymore