### PR TITLE
Add dynamic delay calculator for link switch watchdog heartbeat timeout

### DIFF
--- a/bonesms_ws/src/CMakeLists.txt
+++ b/bonesms_ws/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/ros/kinetic/share/catkin/cmake/toplevel.cmake
+/opt/ros/noetic/share/catkin/cmake/toplevel.cmake

--- a/launch/ogc_airtest.launch
+++ b/launch/ogc_airtest.launch
@@ -85,7 +85,6 @@
 		<param name="interval_1" value="$(arg interval_1)" />
 		<param name="interval_2" value="$(arg interval_2)" />
 		<param name="interval_3" value="$(arg interval_3)" />
-
 		<param name="waypoint_folder" value="$(arg waypoint_folder)"/>
 	</node>
 
@@ -104,6 +103,11 @@
 	<!-- linkswitch -->
 	<node name="switcher" type="switcher.py" pkg="despatcher"
 	respawn="true" respawn_delay="3" output="$(arg log_output)">
+		<param name="router_username" value="$(arg router_username)" />
+        <param name="router_ip" value="$(arg router_ip)" />
+		<param name="interval_1" value="$(arg interval_1)" />
+		<param name="interval_2" value="$(arg interval_2)" />
+		<param name="interval_3" value="$(arg interval_3)" />
 	</node>
 
 </launch>

--- a/launch/ogc_gndtest.launch
+++ b/launch/ogc_gndtest.launch
@@ -77,10 +77,16 @@
 	<!-- linkswitch -->
 	<node name="switcher" type="switcher.py" pkg="despatcher"
 	respawn="true" respawn_delay="3" output="$(arg log_output)">
+		<param name="router_username" value="$(arg router_username)" />
+        <param name="router_ip" value="$(arg router_ip)" />
+		<param name="interval_1" value="$(arg interval_1)" />
+		<param name="interval_2" value="$(arg interval_2)" />
+		<param name="interval_3" value="$(arg interval_3)" />
 	</node>
 
 	<!-- timeout -->
-	<node name="feedback_timeout" pkg="despatcher" type="feedback_timeout.py" respawn="true" respawn_delay="3" output="log">
+	<node name="feedback_timeout" pkg="despatcher" type="feedback_timeout.py"
+	respawn="true" respawn_delay="3" output="log">
     </node>
 
 </launch>

--- a/launch/ogc_sitl.launch
+++ b/launch/ogc_sitl.launch
@@ -77,7 +77,11 @@
 	<!-- linkswitch -->
 	<node name="switcher" type="switcher.py" pkg="despatcher"
 	respawn="true" respawn_delay="3" output="$(arg log_output)">
-	<rosparam param="valid_ids" subst_value="True">$(arg ground_ids)</rosparam>
+		<param name="router_username" value="$(arg router_username)" />
+        <param name="router_ip" value="$(arg router_ip)" />
+		<param name="interval_1" value="$(arg interval_1)" />
+		<param name="interval_2" value="$(arg interval_2)" />
+		<param name="interval_3" value="$(arg interval_3)" />
 	</node>
 
 </launch>

--- a/ogc_ws/Changelog.rst
+++ b/ogc_ws/Changelog.rst
@@ -2,6 +2,18 @@
 Changelog for Ops Ground Control Packages
 =========================================
 
+2.1
+------------------
+
+- Dynamic calculation of heartbeat timeout for link switch algorithm
+- Add a latency simulator to test dynamic calculation of heartbeat timeout
+- Bug fix of timestamp not showing in telegram timeout logic (for link switching)
+- Bug fix in get_conntype of RuTOS Module
+- Bug fixes in GCS Setup scripts (see Yonah_scripts repo)
+- Consolidation of AWS Setup folder (see Yonah_scripts repo)
+
+The biggest feature in this release is the addition of a dynamic delay calculator for the link switch heartbeat timeout. It uses TCP's Jacobson Algorithm to dynamically calculate the heartbeat timeout of the link switch algorithm during runtime. A latency simulator is added to simulate high latencies to test the integrity of this feature.
+
 2.0
 ------------------
 

--- a/ogc_ws/src/despatcher/scripts/dynamic_delay.py
+++ b/ogc_ws/src/despatcher/scripts/dynamic_delay.py
@@ -53,9 +53,9 @@ class dynamic_delay():
             self._srtt = 0.875 * self._srtt + 0.125 * r
         self._rto = self._srtt + max(self._clock_gran, 4 * self._rttvar)
 
-    def set_initial_rto(self, t):
-        '''Initialize RTO to t. Used during bootup or on restoration of link'''
-        self._rto = t
+    def init_rto(self):
+        '''Initialize RTO to extended interval. Used during bootup and link recovery'''
+        self._rto = self._extended_inter
         self._first_r = True
 
     def set_interval(self, inter):

--- a/ogc_ws/src/despatcher/scripts/dynamic_delay.py
+++ b/ogc_ws/src/despatcher/scripts/dynamic_delay.py
@@ -3,8 +3,11 @@
 '''
 Dynamically calculate the watchdog countdown interval for switcher node
 
-The algorithm adopts Jacobson's Algorithm for TCP RTT calculation
-as given by RFC6298: https://www.rfc-editor.org/rfc/rfc6298.html
+The interval calculation adopts Jacobson's Algorithm for TCP RTT calculation
+as given by RFC6298: https://tools.ietf.org/html/rfc6298
+
+The recovery behaviour adopts modified version of Eifel Algorithm
+as given by RFC3522: https://tools.ietf.org/html/rfc3522
 '''
 
 # Copyright (C) 2021, Lau Yan Han and Yonah (yonahbox@gmail.com)
@@ -22,21 +25,24 @@ as given by RFC6298: https://www.rfc-editor.org/rfc/rfc6298.html
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from queue import Queue
 import time
 
 class dynamic_delay():
     '''Each link monitor in switcher should spawn an instance of this calculator'''
     def __init__(self):
+        self._inter = 1 # Interval between sender's msgs
+        self._extended_inter = 3 # Extended interval
         self._first_r = True # True = waiting for first incoming msg after startup/restoration of link
         self._srtt = 0 # Smoothed round-trip-time (rtt)
         self._rttvar = 0 # rtt variance
         self._rto = 1 # "Retransmission" timeout. In our case it is the watchdog timeout value
-    
+        self._recovery_rto = 1.5 * self._extended_inter # rto used during recovery phase
+        self._clock_gran = 1 # Clock granularity (seconds)
+
     def calc_rto(self, sent_timestamp):
         '''Calculate Retransmission Timeout according to Jacobson's Algo (RFC6298)'''
         recv_timestamp = time.time().seconds
-        r = recv_timestamp - sent_timestamp # r = measured rtt
+        r = recv_timestamp - sent_timestamp + self._inter # r = measured rtt
         if self._first_r:
             self._rttvar = 0.5*r
             self._srtt = r
@@ -45,12 +51,18 @@ class dynamic_delay():
             # Use RFC recommended values of alpha = 0.125 and beta = 0.25. Numbers are hardcoded to save memory
             self._rttvar = 0.75 * self._rttvar + 0.25 * abs(self._srtt - r)
             self._srtt = 0.875 * self._srtt + 0.125 * r
-        self._rto = self._srtt + 4 * self._rttvar
+        self._rto = self._srtt + max(self._clock_gran, 4 * self._rttvar)
 
     def set_initial_rto(self, t):
         '''Initialize RTO to t. Used during bootup or on restoration of link'''
         self._rto = t
         self._first_r = True
+
+    def set_interval(self, inter):
+        self._inter = inter
+
+    def set_extended_interval(self, extended_inter):
+        self._extended_inter = extended_inter
     
     def get_rto(self):
         return self._rto

--- a/ogc_ws/src/despatcher/scripts/dynamic_delay.py
+++ b/ogc_ws/src/despatcher/scripts/dynamic_delay.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+
+'''
+Dynamically calculate the watchdog countdown interval for switcher node
+
+The algorithm adopts Jacobson's Algorithm for TCP RTT calculation
+as given by RFC6298: https://www.rfc-editor.org/rfc/rfc6298.html
+'''
+
+# Copyright (C) 2021, Lau Yan Han and Yonah (yonahbox@gmail.com)
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from queue import Queue
+import time
+
+class dynamic_delay():
+    '''Each link monitor in switcher should spawn an instance of this calculator'''
+    def __init__(self):
+        self._first_r = True # True = waiting for first incoming msg after startup/restoration of link
+        self._srtt = 0 # Smoothed round-trip-time (rtt)
+        self._rttvar = 0 # rtt variance
+        self._rto = 1 # "Retransmission" timeout. In our case it is the watchdog timeout value
+    
+    def calc_rto(self, sent_timestamp):
+        '''Calculate Retransmission Timeout according to Jacobson's Algo (RFC6298)'''
+        recv_timestamp = time.time().seconds
+        r = recv_timestamp - sent_timestamp # r = measured rtt
+        if self._first_r:
+            self._rttvar = 0.5*r
+            self._srtt = r
+            self._first_r = False
+        else:
+            # Use RFC recommended values of alpha = 0.125 and beta = 0.25. Numbers are hardcoded to save memory
+            self._rttvar = 0.75 * self._rttvar + 0.25 * abs(self._srtt - r)
+            self._srtt = 0.875 * self._srtt + 0.125 * r
+        self._rto = self._srtt + 4 * self._rttvar
+
+    def set_initial_rto(self, t):
+        '''Initialize RTO to t. Used during bootup or on restoration of link'''
+        self._rto = t
+        self._first_r = True
+    
+    def get_rto(self):
+        return self._rto
+

--- a/ogc_ws/src/despatcher/scripts/dynamic_delay.py
+++ b/ogc_ws/src/despatcher/scripts/dynamic_delay.py
@@ -71,5 +71,8 @@ class dynamic_delay():
     def get_rto(self):
         return self._rto
 
+    def get_interval(self):
+        return self._inter
+
     def get_link_state(self):
         return self._link_state

--- a/ogc_ws/src/despatcher/scripts/dynamic_delay.py
+++ b/ogc_ws/src/despatcher/scripts/dynamic_delay.py
@@ -5,9 +5,6 @@ Dynamically calculate the watchdog countdown interval for switcher node
 
 The interval calculation adopts Jacobson's Algorithm for TCP RTT calculation
 as given by RFC6298: https://tools.ietf.org/html/rfc6298
-
-The recovery behaviour adopts modified version of Eifel Algorithm
-as given by RFC3522: https://tools.ietf.org/html/rfc3522
 '''
 
 # Copyright (C) 2021, Lau Yan Han and Yonah (yonahbox@gmail.com)

--- a/ogc_ws/src/despatcher/scripts/dynamic_delay.py
+++ b/ogc_ws/src/despatcher/scripts/dynamic_delay.py
@@ -43,7 +43,7 @@ class dynamic_delay():
         '''Calculate Retransmission Timeout according to Jacobson's Algo (RFC6298)'''
         if self._link_state == -1:
             return
-        recv_timestamp = time.time().seconds
+        recv_timestamp = int(time.time())
         r = recv_timestamp - sent_timestamp + self._inter # r = measured rtt
         if self._link_state == 0:
             self._rttvar = 0.5*r

--- a/ogc_ws/src/despatcher/setup.py
+++ b/ogc_ws/src/despatcher/setup.py
@@ -4,7 +4,7 @@ from distutils.core import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 setup_args = generate_distutils_setup(
-     packages=['g2a', 'headers', 'regular', 'waypoint', 'feedback_util'],
+     packages=['dynamic_delay', 'feedback_util', 'g2a', 'headers', 'regular', 'waypoint'],
      package_dir={'': 'scripts'}
 )
 

--- a/ogc_ws/src/despatcher/src/feedback_timeout.py
+++ b/ogc_ws/src/despatcher/src/feedback_timeout.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 '''
-timeout: A timeout tracker for each command message sent from rqt
+feedback_timeout: A timeout tracker for each command message sent from rqt
 
 Copyright (C) 2020 Dani Purwadi and Yonah (yonahbox@gmail.com)
 
@@ -53,7 +53,7 @@ class MessageTimer():
 class Manager():
     '''Main class that handles the incoming information'''
     def __init__(self):
-        rospy.init_node('timeout', anonymous=False)
+        rospy.init_node('feedback_timeout', anonymous=False)
         self.messages = {} # Stores all the messages as MessageTimer classes
     
     def watcher(self):

--- a/ogc_ws/src/despatcher/src/gnd_despatcher.py
+++ b/ogc_ws/src/despatcher/src/gnd_despatcher.py
@@ -82,7 +82,7 @@ class aircraft():
     def switch_link(self, link):
         self._link = link
         if self._link == SBD:
-            self._tele_interval = rospy.get_param("~interval_3")
+            self._tele_interval = rospy.get_param("~interval_2")
             self._sms_interval = rospy.get_param("~interval_3")
         elif self._link == SMS:
             self._tele_interval = rospy.get_param("~interval_2")
@@ -136,19 +136,15 @@ class gnddespatcher():
             self._aircrafts[i] = aircraft(i)
 
     def update_valid_ids_cb(self, msg):
+        '''Callback function to obtain updated list of valid ids from the admin server'''
         self._valid_ids = [i for i in msg.data]
-
+        # clear and recreate self._new_msg_chk and self._aircrafts, since they are dependent on valid id list
         del self._new_msg_chk
         self._new_msg_chk = headers.new_msg_chk(self._valid_ids)
-
-
         for j in self._aircrafts.keys():
             self._aircrafts[j].kill_timers()
-
-        # clear and recreate self._aircrafts
         del self._aircrafts
         self._aircrafts = {}
-
         for i in self._valid_ids:
             self._aircrafts[i] = aircraft(i)
 

--- a/ogc_ws/src/despatcher/src/switcher.py
+++ b/ogc_ws/src/despatcher/src/switcher.py
@@ -142,7 +142,7 @@ class switcher():
             env_home = '/home/lenovo' # Since this is only for simulation, we can hardcode the home directory
             self.csvfile = open(f'{env_home}/sim.csv', 'w')
             self.writer = csv.writer(self.csvfile)
-            self.writer.writerow(['sent_timestamp', 'true rtt', 'est rto'])
+            self.writer.writerow(['sent_timestamp', 'true latency', 'est latency'])
             self._fake_latency = 0
 
     def update_valid_ids_cb(self, msg):
@@ -198,7 +198,9 @@ class switcher():
         if SIM:
             rto = self._watchdogs[sysid].get_rto(link)
             inter = self._watchdogs[sysid].get_interval(link)
-            self.writer.writerows([str(sent_timestamp), str(inter + self._fake_latency), str(rto)])
+            rospy.loginfo(f"Switcher: Est latency = {inter + self._fake_latency}")
+            rospy.loginfo(f"Switcher: True latency = {inter + self._fake_latency}")
+            self.writer.writerow([sent_timestamp, inter + self._fake_latency, rto])
 
     def monitor_tele(self, data):
         '''Monitor telegram link for incoming msgs'''

--- a/ogc_ws/src/despatcher/src/switcher.py
+++ b/ogc_ws/src/despatcher/src/switcher.py
@@ -49,7 +49,7 @@ class watchdog():
         self.countdown_handler = rospy.Timer(rospy.Duration(1), self.countdown)
 
     def _print_rto_update(self, link):
-        rospy.logwarn(f"Switcher: Device {self._client_id}, link {link} watchdog set to {self._watchdog[link]} secs")
+        rospy.logwarn(f"Switcher: Client {self._client_id}, link {link} watchdog set to {self._watchdog[link]} secs")
     
     def _init_delay_calc_and_timer(self):
         '''Initialise dynamic delay calculators and watchdog timers for each link in the watchdog'''
@@ -79,7 +79,7 @@ class watchdog():
         if target_link == SMS and SMS_timedout:
             target_link = SBD
         self._link = target_link
-        rospy.logwarn("Switcher: Client " + str(self._client_id) +  " switching to link " + str(target_link))
+        rospy.logwarn(f"Switcher: Client {self._client_id} switching to link {target_link}")
         self.pub_to_despatcher.publish(str(self._client_id) + " " + str(self._link))
         if target_link <= SMS:
             self._delay_calc[target_link].reset_rto() # Set rto to its beginning value
@@ -92,7 +92,7 @@ class watchdog():
             return
         self._watchdog[self._link] = self._watchdog[self._link] - 1
         if self._watchdog[self._link] <= 0:
-            rospy.logwarn(f"Switcher: {self._link} watchdog expired")
+            rospy.logwarn(f"Switcher: Client {self._client_id}, link {self._link} watchdog expired")
             self._delay_calc[self._link].set_link_state(-1) # Tell delay calculator that this link is down
             self.switch(self._link + 1)
     

--- a/ogc_ws/src/despatcher/src/switcher.py
+++ b/ogc_ws/src/despatcher/src/switcher.py
@@ -135,9 +135,9 @@ class switcher():
         
         # Log rto data if doing high latency simulation
         if SIM:
-            with open('sim.csv', 'w') as csvfile:
-                self.writer = csv.writer(csvfile)
-                self.writer.writerow(['sent_timestamp', 'rto'])
+            csvfile = open('sim.csv', 'w')
+            self.writer = csv.writer(csvfile)
+            self.writer.writerow(['sent_timestamp', 'rto'])
 
     def update_valid_ids_cb(self, msg):
         '''Callback function to obtain updated list of valid ids from the admin server'''

--- a/ogc_ws/src/despatcher/src/switcher.py
+++ b/ogc_ws/src/despatcher/src/switcher.py
@@ -31,7 +31,7 @@ TELE = 0
 SMS = 1
 SBD = 2
 
-SIM = True # High latency simulator toggle
+SIM = False # High latency simulator toggle
 SMS_timedout = False #@TODO: Why is SMS_timedout declared here and then again in the switcher class???
 
 if SIM:

--- a/ogc_ws/src/despatcher/src/switcher.py
+++ b/ogc_ws/src/despatcher/src/switcher.py
@@ -135,8 +135,9 @@ class switcher():
         
         # Log rto data if doing high latency simulation
         if SIM:
-            csvfile = open('sim.csv', 'w')
-            self.writer = csv.writer(csvfile)
+            env_home = '/home/lenovo' # Since this is only for simulation, we can hardcode the home directory
+            self.csvfile = open(f'{env_home}/sim.csv', 'w')
+            self.writer = csv.writer(self.csvfile)
             self.writer.writerow(['sent_timestamp', 'rto'])
 
     def update_valid_ids_cb(self, msg):
@@ -265,7 +266,7 @@ class switcher():
         router_monitor = rospy.Timer(rospy.Duration(5), self.monitor_router)
         rospy.spin()
         router_monitor.shutdown()
-        self.writer.close()
+        self.csvfile.close()
 
 if __name__=='__main__':
     run = switcher()

--- a/ogc_ws/src/despatcher/src/switcher.py
+++ b/ogc_ws/src/despatcher/src/switcher.py
@@ -198,7 +198,7 @@ class switcher():
         if SIM:
             rto = self._watchdogs[sysid].get_rto(link)
             inter = self._watchdogs[sysid].get_interval(link)
-            rospy.loginfo(f"Switcher: Est latency = {inter + self._fake_latency}")
+            rospy.loginfo(f"Switcher: Est latency = {rto}")
             rospy.loginfo(f"Switcher: True latency = {inter + self._fake_latency}")
             self.writer.writerow([sent_timestamp, inter + self._fake_latency, rto])
 

--- a/ogc_ws/src/despatcher/src/switcher.py
+++ b/ogc_ws/src/despatcher/src/switcher.py
@@ -60,6 +60,7 @@ class watchdog():
     
     def countdown(self, data):
         '''Decrement the watchdog by 1 second. When watchdog expires, trigger the link switch'''
+        #TODO: Possibly have to decrease the sleep rate to 0.1s for more accurate dynamic delay
         if self._link >= SBD:
             return
         self._watchdog[self._link] = self._watchdog[self._link] - 1
@@ -125,16 +126,16 @@ class switcher():
     ###########################
     
     def _is_valid_msg(self, msg):
-        '''Takes in a string msg. Return true + sender's sysid if msg is valid'''
+        '''Takes in a string msg. Return true + sender's sysid + timestamp if msg is valid'''
         try:
             msgtype, devicetype, sysid, uuid, timestamp, entries \
                 = headers.split_headers(msg)
             if not self._new_msg_chk.is_new_msg(timestamp, sysid):
-                return False, 0
+                return False, 0, 0
             else:
-                return True, sysid
+                return True, sysid, timestamp
         except (ValueError, IndexError, TypeError):
-            False, 0
+            False, 0, 0
     
     def _monitor_common(self, sysid, link):
         '''Manage link status of the client with the specified sysid'''
@@ -147,13 +148,13 @@ class switcher():
     
     def monitor_tele(self, data):
         '''Monitor telegram link for incoming msgs'''
-        valid, sender_sysid = self._is_valid_msg(data.data)
+        valid, sender_sysid, sent_timestamp = self._is_valid_msg(data.data)
         if valid:
             self._monitor_common(sender_sysid, TELE)
 
     def monitor_sms(self, data):
         '''Monitor sms link for incoming msgs'''
-        valid, sender_sysid = self._is_valid_msg(data.data)
+        valid, sender_sysid, sent_timestamp = self._is_valid_msg(data.data)
         if valid:
             self._monitor_common(sender_sysid, SMS)
 

--- a/ogc_ws/src/despatcher/src/switcher.py
+++ b/ogc_ws/src/despatcher/src/switcher.py
@@ -49,7 +49,7 @@ class watchdog():
         self.countdown_handler = rospy.Timer(rospy.Duration(1), self.countdown)
 
     def _print_rto_update(self, link):
-        rospy.logwarn(f"Switcher: Client {self._client_id}, link {link} watchdog set to {self._watchdog[link]} secs")
+        rospy.loginfo(f"Switcher: Client {self._client_id}, link {link} watchdog set to {self._watchdog[link]} secs")
     
     def _init_delay_calc_and_timer(self):
         '''Initialise dynamic delay calculators and watchdog timers for each link in the watchdog'''

--- a/ogc_ws/src/despatcher/src/switcher.py
+++ b/ogc_ws/src/despatcher/src/switcher.py
@@ -212,7 +212,7 @@ class switcher():
         if valid:
             if SIM:
                 self._sim_latency()
-                rospy.sleep(self._fake_latency) # Simulate high latency
+                sent_timestamp -= self._fake_latency # Simulate high latency
             self._monitor_common(sender_sysid, TELE, sent_timestamp)
 
     def monitor_sms(self, data):

--- a/ogc_ws/src/despatcher/src/switcher.py
+++ b/ogc_ws/src/despatcher/src/switcher.py
@@ -169,7 +169,11 @@ class switcher():
         '''Generate simulated latency from a normal distribution'''
         mean = 1 # Edit mean and standard deviations here
         stdev = 0.1
-        self._fake_latency = numpy.random.normal(mean, stdev, 1)[0]
+        temp = numpy.random.normal(mean, stdev, 1)[0]
+        if temp < 0:
+            self._fake_latency = 0
+        else:
+            self._fake_latency = temp
 
     ###########################
     # Baseline Link Monitors

--- a/ogc_ws/src/sms/scripts/RuTOS.py
+++ b/ogc_ws/src/sms/scripts/RuTOS.py
@@ -94,8 +94,11 @@ def get_gps_speed(ssh):
 def get_conntype(ssh):
     '''Get type of connection'''
     _, stdout, _ = ssh.exec_command("gpsctl -t")
-    conntype = stdout.readlines()[0]
-    return conntype
+    try:
+        conntype = stdout.readlines()[0].rstrip()
+        return conntype
+    except IndexError: # If command returns blank line
+        return None
 
 def get_rssi(ssh):
     '''Get RSSI'''

--- a/ogc_ws/src/telegram/launch/telegram_gnd.launch
+++ b/ogc_ws/src/telegram/launch/telegram_gnd.launch
@@ -58,6 +58,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	<node name="yonah_rqt" pkg="rqt_gui" type="rqt_gui" respawn="true" respawn_delay="3" output="$(arg log_output)">
 		</node>
 
-	<node name="feedback timeout" pkg="despatcher" type="feedback_timeout.py" respawn="true" respawn_delay="3" output="log">
+	<node name="feedback_timeout" pkg="despatcher" type="feedback_timeout.py" respawn="true" respawn_delay="3" output="log">
     </node>
 </launch>

--- a/ogc_ws/src/telegram/src/telegram_link
+++ b/ogc_ws/src/telegram/src/telegram_link
@@ -44,6 +44,7 @@ class LinkSwitchTimeout():
 
 	def countdown(self, data):
 		self.time -= 1
+		rospy.logwarn(f"Tele: {self.timestamp} countdown: {self.time}")
 		if self.time <= 0:
 			self.timer.shutdown()
 			self.pub_to_switcher.publish("Timeout")
@@ -202,7 +203,7 @@ def tdlib_recv():
 				if event['message']['content']['@type'] == 'messageText':
 					if int(event["message"]["content"]["text"]["text"].split()[3]) == 0:
 						timestamp = int(event["message"]["content"]["text"]["text"].split()[-1])
-						if hasattr(tdtimeout, str(timestamp)):
+						if timestamp in tdtimeout:
 							if hasattr(tdtimeout[timestamp],"timer"):
 								tdtimeout[timestamp].timer.shutdown()
 								tdtimeout[timestamp].pub_to_switcher.publish("Success")

--- a/ogc_ws/src/telegram/src/telegram_link
+++ b/ogc_ws/src/telegram/src/telegram_link
@@ -32,6 +32,7 @@ import sys
 from Td import Td
 
 tdtimeout = {}
+DEBUG = False
 
 class LinkSwitchTimeout():
 	# Checks if outgoing msgs take too long to reach the Tele Servers
@@ -44,7 +45,8 @@ class LinkSwitchTimeout():
 
 	def countdown(self, data):
 		self.time -= 1
-		rospy.logwarn(f"Tele: {self.timestamp} countdown: {self.time}")
+		if DEBUG:
+			rospy.logwarn(f"Tele: {self.timestamp} countdown: {self.time}")
 		if self.time <= 0:
 			self.timer.shutdown()
 			self.pub_to_switcher.publish("Timeout")


### PR DESCRIPTION
This adds an algorithm that dynamically calculates the watchdog timeout module for the link switch heartbeat algorithm. The code is based on TCP's Jacobson Algorithm (given in [RFC6298](https://tools.ietf.org/html/rfc6298)). The module (`dynamic_delay.py`) is found in the despatcher package

Other minor edits include:

- Add a latency simulator to test the dynamic delay module
- Bug fix of timestamp not showing in telegram timeout logic (for link switching)
- Bug fix in get_conntype of RuTOS Module
- Bug fixes in GCS Setup scripts (see [Yonah_scripts](https://github.com/yonahbox/Yonah_scripts/) repo)
- Consolidation of AWS Setup folder (see Yonah_scripts repo)